### PR TITLE
chore: release v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/ThorstenHans/spin-contrib-http/compare/v0.0.3...v0.0.4) - 2024-04-26
+
+### Other
+- remove deps and println statements
+
 ## [0.0.3](https://github.com/ThorstenHans/spin-contrib-http/compare/v0.0.2...v0.0.3) - 2024-04-26
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-contrib-http"
-version = "0.0.3"
+version = "0.0.4"
 description = "Bunch of helpers for building HTTP services using Fermyon Spin"
 authors = ["Thorsten Hans <thorsten.hans@gmail.com>"]
 repository = "https://github.com/ThorstenHans/spin-contrib-http"


### PR DESCRIPTION
## 🤖 New release
* `spin-contrib-http`: 0.0.3 -> 0.0.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.4](https://github.com/ThorstenHans/spin-contrib-http/compare/v0.0.3...v0.0.4) - 2024-04-26

### Other
- remove deps and println statements
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).