### PR TITLE
chore: release v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5](https://github.com/ThorstenHans/spin-contrib-http/compare/v0.0.4...v0.0.5) - 2024-04-29
+
+### Added
+- [**breaking**] Rewrite CORS according to spec
+
 ## [0.0.4](https://github.com/ThorstenHans/spin-contrib-http/compare/v0.0.3...v0.0.4) - 2024-04-26
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-contrib-http"
-version = "0.0.4"
+version = "0.0.5"
 description = "Bunch of helpers for building HTTP services using Fermyon Spin"
 authors = ["Thorsten Hans <thorsten.hans@gmail.com>"]
 repository = "https://github.com/ThorstenHans/spin-contrib-http"


### PR DESCRIPTION
## 🤖 New release
* `spin-contrib-http`: 0.0.4 -> 0.0.5 (⚠️ API breaking changes)

### ⚠️ `spin-contrib-http` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/inherent_method_missing.ron

Failed in:
  CorsConfig::is_origin_allowed, previously in file /tmp/.tmpCz3QDb/spin-contrib-http/src/cors.rs:19
  CorsConfig::is_method_allowed, previously in file /tmp/.tmpCz3QDb/spin-contrib-http/src/cors.rs:36

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field allowed_origins of struct CorsConfig, previously in file /tmp/.tmpCz3QDb/spin-contrib-http/src/cors.rs:6
  field allowed_methods of struct CorsConfig, previously in file /tmp/.tmpCz3QDb/spin-contrib-http/src/cors.rs:8
  field allowed_headers of struct CorsConfig, previously in file /tmp/.tmpCz3QDb/spin-contrib-http/src/cors.rs:10
  field allow_credentials of struct CorsConfig, previously in file /tmp/.tmpCz3QDb/spin-contrib-http/src/cors.rs:12
  field max_age of struct CorsConfig, previously in file /tmp/.tmpCz3QDb/spin-contrib-http/src/cors.rs:14

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field CorsConfig.allowed_origins in file /tmp/.tmp4QOFEF/spin-contrib-http/src/cors/config.rs:4
  field CorsConfig.allowed_methods in file /tmp/.tmp4QOFEF/spin-contrib-http/src/cors/config.rs:4
  field CorsConfig.allowed_headers in file /tmp/.tmp4QOFEF/spin-contrib-http/src/cors/config.rs:4
  field CorsConfig.allow_credentials in file /tmp/.tmp4QOFEF/spin-contrib-http/src/cors/config.rs:4
  field CorsConfig.max_age in file /tmp/.tmp4QOFEF/spin-contrib-http/src/cors/config.rs:4
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.5](https://github.com/ThorstenHans/spin-contrib-http/compare/v0.0.4...v0.0.5) - 2024-04-29

### Added
- [**breaking**] Rewrite CORS according to spec
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).