### PR TITLE
feat: reactor CORS API (BREAKING)

### DIFF
--- a/src/cors/router.rs
+++ b/src/cors/router.rs
@@ -47,7 +47,7 @@ fn options_handler(req: &Request, cors_config: &CorsConfig) -> anyhow::Result<Re
     {
         return Ok(Response::new(405, ()));
     }
-    let headers = build_cors_headers(req, cors_config);
+    let headers = build_cors_headers(req.method(), req_origin, cors_config);
     Ok(ResponseBuilder::new(http::StatusCode::NO_CONTENT)
         .headers(headers)
         .body(())


### PR DESCRIPTION
With this PR,  the public API for CORS changes a bit. Users do not have to pass the entire request to the API for building CORS-enabled requests. Instead the request method (`&Method`) and the value of the `ORIGIN` request header as simple `String` are enough.