### PR TITLE
chore: release v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/ThorstenHans/spin-contrib-http/compare/v0.0.5...v0.0.6) - 2024-05-08
+
+### Added
+- reactor CORS API (BREAKING)
+
 ## [0.0.5](https://github.com/ThorstenHans/spin-contrib-http/compare/v0.0.4...v0.0.5) - 2024-04-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-contrib-http"
-version = "0.0.5"
+version = "0.0.6"
 description = "Bunch of helpers for building HTTP services using Fermyon Spin"
 authors = ["Thorsten Hans <thorsten.hans@gmail.com>"]
 repository = "https://github.com/ThorstenHans/spin-contrib-http"


### PR DESCRIPTION
## 🤖 New release
* `spin-contrib-http`: 0.0.5 -> 0.0.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.6](https://github.com/ThorstenHans/spin-contrib-http/compare/v0.0.5...v0.0.6) - 2024-05-08

### Added
- reactor CORS API (BREAKING)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).