### PR TITLE
Check Allowed Origins

### DIFF
--- a/examples/cors-usage/README.md
+++ b/examples/cors-usage/README.md
@@ -20,7 +20,7 @@ You can use `curl` to send test requests to the app. Please keep in mind that CO
 
 Samples listed below construct resources based on the following `CorsConfig` instance:
 
-``rust
+```rust
     CorsConfig::new(
         ALL_ORIGINS.to_string(),
         ALL_METHODS.to_string(),

--- a/src/cors/config.rs
+++ b/src/cors/config.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use super::NO_ORIGINS;
 
 /// This struct is used to configure CORS support
@@ -35,6 +37,18 @@ impl CorsConfig {
             allow_credentials,
             max_age,
         }
+    }
+}
+
+impl Debug for CorsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CorsConfig")
+            .field("allowed_origins", &self.allowed_origins)
+            .field("allowed_methods", &self.allowed_methods)
+            .field("allowed_headers", &self.allowed_headers)
+            .field("allow_credentials", &self.allow_credentials)
+            .field("max_age", &self.max_age)
+            .finish()
     }
 }
 

--- a/src/cors/responsebuilder.rs
+++ b/src/cors/responsebuilder.rs
@@ -1,6 +1,6 @@
 use spin_sdk::http::{Method, Response, ResponseBuilder};
 
-use super::{build_cors_headers, CorsConfig};
+use super::{build_cors_headers, is_origin_allowed, CorsConfig, ALL_ORIGINS};
 
 /// Trait to add CORS capabilities
 pub trait CorsResponseBuilder {
@@ -20,6 +20,14 @@ impl CorsResponseBuilder for ResponseBuilder {
         request_origin: String,
         cors_config: &CorsConfig,
     ) -> Response {
+        if !request_origin.is_empty()
+            && cors_config.allowed_origins != ALL_ORIGINS
+            && !is_origin_allowed(&cors_config.allowed_origins, &request_origin)
+        {
+            self.status(403);
+            self.body(());
+        }
+
         let headers = build_cors_headers(request_method, request_origin, cors_config);
         self.headers(headers).build()
     }


### PR DESCRIPTION
With this PR allowed origins are checked for every request if an `Origin` header is present and ALLOWED_ORIGINS is not set to `ALL_ORIGINS`

Additional contribs:

- Implement `Debug` trait for `CorsConfig`
- Update example docs and fix a code-block formatting issue