### PR TITLE
chore: release v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8](https://github.com/ThorstenHans/spin-contrib-http/compare/v0.0.7...v0.0.8) - 2024-06-04
+
+### Other
+- check allowed origins on every request if ORIGIN is present
+- implement Debug trait for CorsConfig
+
 ## [0.0.7](https://github.com/ThorstenHans/spin-contrib-http/compare/v0.0.6...v0.0.7) - 2024-05-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-contrib-http"
-version = "0.0.7"
+version = "0.0.8"
 description = "Bunch of helpers for building HTTP services using Fermyon Spin"
 authors = ["Thorsten Hans <thorsten.hans@gmail.com>"]
 repository = "https://github.com/ThorstenHans/spin-contrib-http"


### PR DESCRIPTION
## 🤖 New release
* `spin-contrib-http`: 0.0.7 -> 0.0.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.8](https://github.com/ThorstenHans/spin-contrib-http/compare/v0.0.7...v0.0.8) - 2024-06-04

### Other
- check allowed origins on every request if ORIGIN is present
- implement Debug trait for CorsConfig
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).